### PR TITLE
Use canonical import path

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -17,7 +17,7 @@ package log
 // based on previous package by: Cong Ding <dinggnu@gmail.com>
 
 import (
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"os"
 	"path"
 	"time"


### PR DESCRIPTION
Yay go!  Someone changed a canonical import path and broke consumers.  Awesome!  We have a transitive dep on this and go get is busted.